### PR TITLE
Add documentation on how to install "User Themes"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,13 @@
 
 ![](./screenshot/screen-2.png)
 
-
 ## Installation
+
+### Requirements
+
+You need to enable the [User Themes](https://extensions.gnome.org/extension/19/user-themes/) GNOME Shell Extension.
+
+Follow the link and flick the switch to "on" to enable it.
 
 **If you want to install it manually:**
 


### PR DESCRIPTION
The "User Themes" GNOME Shell Extension is needed for this theme to work from the ~/.themes folder. Without it, the ~/.themes folder will not be registered.

This pull-request introduces a bit of explaining on the fact that this is dependent upon the User Themes extension and how to enable it.