### PR TITLE
Use symbolic links so that git folder can be kept

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,19 @@
 **If you want to install it manually:**
 
 - Download and uncompress the zip file.
-- Move `flat-dark` to your `.themes` directory in your home directory.
+- Either move `flat-dark` to your `.themes` directory in your home directory;
+  or create a symbolic link to the folder (ctrl-shift drag does this in Nautilus).
   If the directory `.themes` does not exist create it.
 - Select "Flat Dark" as shell theme in gnomes Tweak Tool.
 
 **If you prefer to use the terminal:**
 
 ```
-cd /tmp
+mkdir ~/available-themes
+mkdir ~/.themes
+cd ~/available-themes
 git clone https://github.com/nerdbeere/flat-dark-gnome-theme
-mkdir -p ~/.themes
-mv flat-dark-gnome-theme/flat-dark ~/.themes
+ln -s ~/available-themes/flat-dark-gnome-theme/flat-dark ~/.themes/flat-dark
 ```
 
 ## Icons


### PR DESCRIPTION
When you keep the git folder in a specific place, you can get updates from the repository just by doing a `git pull`. If you move the folder from the git repository to the `~/.themes` folder, that mechanism is lost.

This way, you keep the link to GitHub, allowing to import changes very easily, without having to re-copy stuff.